### PR TITLE
[DRAFT] Use server.el to manage frame lifecycle

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -192,13 +192,12 @@ Never paste content when ABORT is non-nil."
       (run-hooks 'emacs-everywhere-final-hooks)
       (gui-select-text (buffer-string))
       (unless (eq system-type 'darwin) ; handle clipboard finicklyness
-        (let ((clip-file (make-temp-file "ee-clipboard"))
-              (inhibit-message t)
+        (let ((inhibit-message t)
               (require-final-newline nil)
               write-file-functions)
+          (write-file buffer-file-name)
           (pp (buffer-string))
-          (write-file clip-file)
-          (call-process "xclip" nil nil nil "-selection" "clipboard" clip-file))))
+          (call-process "xclip" nil nil nil "-selection" "clipboard" buffer-file-name))))
     (sit-for 0.01) ; prevents weird multi-second pause, lets clipboard info propagate
     (let ((window-id (emacs-everywhere-app-id emacs-everywhere-current-app)))
       (if (eq system-type 'darwin)

--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -86,9 +86,9 @@ Formatted with the app name, and truncated window name."
 
 (defcustom emacs-everywhere-file-patterns
   (let ((default-directory temporary-file-directory))
-    (list (concat "^" (regexp-quote (expand-file-name "emacs-everywhere-")))
+    (list (concat "^" (regexp-quote (file-truename "emacs-everywhere-")))
           ;; For qutebrowser 'editor.command' support
-          (concat "^" (regexp-quote (expand-file-name "qutebrowser-editor-")))))
+          (concat "^" (regexp-quote (file-truename "qutebrowser-editor-")))))
   "A list of file regexps to activate `emacs-everywhere-mode' for."
   :type '(repeat regexp)
   :group 'emacs-everywhere)
@@ -130,8 +130,9 @@ Formatted with the app name, and truncated window name."
 (defun emacs-everywhere-file-p (file)
   "Return non-nil if FILE should be handled by emacs-everywhere.
 This matches FILE against `emacs-everywhere-file-patterns'."
-  (cl-some (lambda (pattern) (string-match-p pattern file))
-           emacs-everywhere-file-patterns))
+  (let ((file (file-truename file)))
+    (cl-some (lambda (pattern) (string-match-p pattern file))
+             emacs-everywhere-file-patterns)))
 
 ;;;###autoload
 (defun emacs-everywhere-initialise ()


### PR DESCRIPTION
server.el has its own frame management logic for temporary frames. We can exploit this to offload some edge-case work to Emacs while opening up emacs-everywhere for use with apps/browsers with dedicated EDITOR support like qutebrowser or vimb.

With this, emacs-everywhere has two entry points:

1. `emacsclient --eval "(emacs-everywhere)"` (the original entry point) and
2. Opening any file that matches one of `emacs-everywhere-file-patterns` (currently `^/tmp/emacs-everywhere-` and `^/tmp/qutebrowser-editor-`)

NOTE: Do not merge this yet. It still needs testing on macOS, which I'll do tomorrow if someone else doesn't beat me to it.