### PR TITLE
Minor refactors

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -388,18 +388,19 @@ Should end in a newline to avoid interfering with the buffer content."
  :type 'string
  :group 'emacs-everywhere)
 
+(defvar org-export-show-temporary-export-buffer)
 (defun emacs-everywhere-return-converted-org-to-gfm ()
   "When appropriate, convert org buffer to markdown."
   (when (and (eq major-mode 'org-mode)
              (emacs-everywhere-markdown-p))
     (goto-char (point-min))
     (insert emacs-everywhere-org-export-options)
-    (let ((export-buffer (generate-new-buffer "*Emacs Everywhere Export*")))
-      (org-export-to-buffer (if (featurep 'ox-gfm) 'gfm 'md) export-buffer)
-      (delete-window)
-      (erase-buffer)
-      (insert-buffer-substring export-buffer)
-      (kill-buffer export-buffer))))
+    (let ((export-buffer (generate-new-buffer "*Emacs Everywhere Export*"))
+          org-export-show-temporary-export-buffer) ; don't create a split!
+      (unwind-protect
+          (replace-buffer-contents
+           (org-export-to-buffer (if (featurep 'ox-gfm) 'gfm 'md) (current-buffer)))
+        (kill-buffer export-buffer)))))
 
 (provide 'emacs-everywhere)
 ;;; emacs-everywhere.el ends here


### PR DESCRIPTION
Some minor refactors to improve error handling, code quality, and make it easier for users to customize/hack this package.

+ Defines `emacs-everywhere-mode-initial-map` for the transient DEL/C-SPC keys. It can be set to `nil` to disable this behavior, or its keys rebound if preferred.
+ Defines named commands for `C-c C-c`, `C-c C-k` and `C-x 5 0`, which can be remapped or advised (anonymous commands could not -- not trivially, at least).
+ Refactors `emacs-everywhere-return-converted-org-to-gfm` to:
  + Resist edge cases concerning window focus (e.g. a particular `display-buffer-alist` config may change what window is focused after `org-export-to-buffer` runs; the ensuing `delete-window` would then delete the wrong window). By unsetting `org-export-show-temporary-export-buffer` instead, I ensure no new window is created to begin with. The intention is clearer and fewer assumptions about window focus are made.
  + Clean up `export-buffer` despite errors to prevent runaway generation of temp buffers in long running Emacs daemon sessions.