### PR TITLE
Minor fixes

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -153,10 +153,8 @@ APP is an `emacs-everywhere-app' struct."
 
 (defvar emacs-everywhere-mode-initial-map
   (let ((keymap (make-sparse-keymap)))
-    (define-key keymap (kbd "DEL")
-      (lambda () (interactive) (delete-region (point-min) (point-max))))
-    (define-key keymap (kbd "C-SPC")
-      (lambda () (interactive) (delete-region (point-min) (point-max))))
+    (define-key keymap (kbd "DEL") #'emacs-everywhere-erase-buffer)
+    (define-key keymap (kbd "C-SPC") #'emacs-everywhere-erase-buffer)
     keymap)
   "Transient keymap invoked when an emacs-everywhere buffer is first created.
 Set to `nil' to prevent this transient map from activating in emacs-everywhere
@@ -174,6 +172,11 @@ buffers.")
   ;; DEL/C-SPC to clear (first keystroke only)
   (when (keymapp emacs-everywhere-mode-initial-map)
     (set-transient-map emacs-everywhere-mode-initial-map)))
+
+(defun emacs-everywhere-erase-buffer ()
+  "Delete the contents of the current buffer."
+  (interactive)
+  (delete-region (point-min) (point-max)))
 
 (defun emacs-everywhere-finish-or-ctrl-c-ctrl-c ()
   "Finish emacs-everywhere session or invoke `org-ctrl-c-ctrl-c' in org-mode."

--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -438,7 +438,8 @@ Should end in a newline to avoid interfering with the buffer content."
              (emacs-everywhere-markdown-p))
     (goto-char (point-min))
     (insert emacs-everywhere-org-export-options)
-    (org-export-to-buffer (if (featurep 'ox-gfm) 'gfm 'md) (current-buffer))))
+    (let (org-export-show-temporary-export-buffer)
+      (org-export-to-buffer (if (featurep 'ox-gfm) 'gfm 'md) (current-buffer)))))
 
 (provide 'emacs-everywhere)
 ;;; emacs-everywhere.el ends here


### PR DESCRIPTION
+ Use named commands for keybinds (18e8864 explains why)
+ Unsets `org-export-show-temporary-export-buffer` so `org-export-to-buffer` doesn't call `switch-to-buffer-other-window`, which may appear to do nothing, but can have variable behavior depending on the user's `display-buffer-alist` config. Best to avoid that edge case altogether.