### PR TITLE
Bugfix for pasting on macOS

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -219,7 +219,7 @@ Never paste content when ABORT is non-nil."
                  (not abort))
         (if (eq system-type 'darwin)
             (call-process "osascript" nil nil nil
-                          "-e" "tell application \"System Events\" to keystroke (the clipboard as text)")
+                          "-e" "tell application \"System Events\" to keystroke \"v\" using command down")
           (call-process "xdotool" nil nil nil
                         "key" "--clearmodifiers" "Shift+Insert"))))
     ;; Clean up after ourselves in case the buffer survives `server-buffer-done'


### PR DESCRIPTION
This fixes https://github.com/tecosaur/emacs-everywhere/issues/19 on my local.

How did I find the fix?
- Copying from the selection is calling `CMD-c` directly (https://github.com/tecosaur/emacs-everywhere/blob/master/emacs-everywhere.el#L387), so I wonder why not pasting.
- `emacs-anywhere`'s macOS script is calling `CMD-c` as well (https://github.com/zachcurry/emacs-anywhere/blob/master/bin/osx#L55)