### PR TITLE
Use `sleep-for` over `sit-for` to ensure proper clipboard contents #25

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -205,7 +205,7 @@ Never paste content when ABORT is non-nil."
           (write-file buffer-file-name)
           (pp (buffer-string))
           (call-process "xclip" nil nil nil "-selection" "clipboard" buffer-file-name))))
-    (sit-for 0.01) ; prevents weird multi-second pause, lets clipboard info propagate
+    (sleep-for 0.01) ; prevents weird multi-second pause, lets clipboard info propagate
     (let ((window-id (emacs-everywhere-app-id emacs-everywhere-current-app)))
       (if (eq system-type 'darwin)
           (call-process "osascript" nil nil nil
@@ -386,7 +386,7 @@ return windowTitle"))
       (progn
         (call-process "osascript" nil nil nil
                       "-e" "tell application \"System Events\" to keystroke \"c\" using command down")
-        (sit-for 0.01) ; lets clipboard info propagate
+        (sleep-for 0.01) ; lets clipboard info propagate
         (yank))
     (when-let ((selection (gui-get-selection 'PRIMARY 'UTF8_STRING)))
       (gui-backend-set-selection 'PRIMARY "")


### PR DESCRIPTION
Sorry for littering your repository with my dumb mistake. 

Recently I've moved from web-based github interaction to magit, so wasn't used to it yet. 

I should have tested it. Now I've tested, and at least in my machine, there's no more malfunction except annoying the verification message for killing the buffer brought by this package for the first time by `C-c C-c`. I'll look through that in my free time.

This issue first brought up in [my comment](https://github.com/tecosaur/emacs-everywhere/issues/24#issuecomment-823799361).

> Today, even with my local, I encountered the same problem as before, the
> instance initiated by `emacs-everywhere` doesn&rsquo;t update its buffer with
> the most recent clipboard content. So I&rsquo;ve experimented more with several
> delay values, and find out that no matter what the delay time,
> `emacs-everywhere` seems to pop up after almost the same time lag, thus,
> determined `sit-for` might be the culprit.
>
> And read the relevant part of [emacs
> manual](https://ftp.gnu.org/old-gnu/Manuals/elisp-manual-21-2.8/html_node/elisp_316.html#:~:text=The%20wait%20functions%20are%20designed,time%20to%20view%20the%20display.),
> and find out we might have had used `sleep-for` rather than `sit-for`, the
> latter is for redisplaying not for the blocking to ensure to stabilize copy and
> paste processes.
>
> I&rsquo;ll open an issue related with it, propose a pull request related to it.

This pull request should resolve the problems around macOS.