### PR TITLE
Pass emacs server name to support multiple emacs servers

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -119,6 +119,9 @@ Formatted with the app name, and truncated window name."
   (apply #'call-process "emacsclient" nil 0 nil
          (delq
           nil (list
+               ;; pass emacs server name to support multiple emacs servers
+               (if server-name
+                   "-s" server-name)
                "-c" "-F"
                (prin1-to-string
                 (cons (cons 'emacs-everywhere-app (emacs-everywhere-app-info))


### PR DESCRIPTION
If the emacs server name is not passed emacs seems to default to using server
name `server`. This change ensures that the current server name is passed along
when the `emacsclient` process is called.