### PR TITLE
Use the same server to launch emacs-everywhere

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -23,6 +23,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'server)
 
 (defgroup emacs-everywhere ()
   "Customise group for Emacs-everywhere."
@@ -119,6 +120,14 @@ Formatted with the app name, and truncated window name."
   (apply #'call-process "emacsclient" nil 0 nil
          (delq
           nil (list
+               (when (server-running-p)
+                 (if server-use-tcp
+                     (concat "--server-file="
+                             (shell-quote-argument
+                              (expand-file-name server-name server-auth-dir)))
+                   (concat "--socket-name="
+                           (shell-quote-argument
+                            (expand-file-name server-name server-socket-dir)))))
                "-c" "-F"
                (prin1-to-string
                 (cons (cons 'emacs-everywhere-app (emacs-everywhere-app-info))


### PR DESCRIPTION
The current implementation assumes that emacs-everywhere should be using the default emacs daemon running. I run multiple instances of emacs daemon for various purposes and ran into issues with this.

You can tell what type of server is running from variables and from that determine the right command line flag to use when launching `emacsclient`. I pulled this logic mostly from the `with-editor` package, but did consolidate the TCP server type to use the flag instead of as an environment variable.

The bottom line of what this PR enables is:

    emacs --daemon=everywhere
    emacsclient -s everywhere -e '(emacs-everywhere)'


Where the final emacs-everywhere frame that opens is run in the `everywhere` emacs daemon and not the default daemon.


Let me know if you have any questions or want changes! Thanks!