### PR TITLE
✨ emacs-everywhere-linux-copy-function emacs-everywhere-paste-cmd

### DIFF
--- a/README.org
+++ b/README.org
@@ -60,8 +60,8 @@ Just call =emacs --daemon= or =M-x server-start= and you're sorted!
    #+begin_src elisp
    ;; "Paste as plaintext" using "Control Shift V" for GTK app Pidgin IM
    (defun emacs-everywhere-pidgin-paste ()
-     (when (eq (emacs-everywhere-app-class emacs-everywhere-current-app) "Pidgin")
-       (set (make-local-variable 'emacs-everywhere-paste-cmd)
+     (when (string= (emacs-everywhere-app-class emacs-everywhere-current-app) "Pidgin")
+       (set 'emacs-everywhere-paste-cmd
             '("xdotool" "key" "--clearmodifiers" "Control+V"))))
 
   (add-hook 'emacs-everywhere-init-hooks 'emacs-everywhere-pidgin-paste)

--- a/README.org
+++ b/README.org
@@ -51,4 +51,26 @@ C-k= still copies the content to the clipboard, but never pastes.
 -----
 
 ^{*†*} This requires the Emacs daemon to be running, but that's super easy.
-Just call =emacs --daemon= and you're sorted!
+Just call =emacs --daemon= or =M-x server-start= and you're sorted!
+
+* Customize
+
+** Example hook
+   The default simulated key chord pastes into Pidgin as a single line. To preserve newlines, the desired combo is =Control+V= (instead of the default =Shift+Insert=). Here we create a function that temporarily modifies the paste command when emacs-everywhere was launched with Pidgin focused.
+   #+begin_src elisp
+   ;; "Paste as plaintext" using "Control Shift V" for GTK app Pidgin IM
+   (defun emacs-everywhere-pidgin-paste ()
+     (when (eq (emacs-everywhere-app-class emacs-everywhere-current-app) "Pidgin")
+       (set (make-local-variable 'emacs-everywhere-paste-cmd)
+            '("xdotool" "key" "--clearmodifiers" "Control+V"))))
+
+  (add-hook 'emacs-everywhere-init-hooks 'emacs-everywhere-pidgin-paste)
+   #+end_src
+
+** Highlights
+
+Window and app names that will open in markdown mode are enumerated in =emacs-everywhere-markdown-windows= and =emacs-everywhere-markdown-apps=.
+
+How the clipboard is handled can be redefined using =emacs-everywhere-linux-copy-function= and  =emacs-everywhere-paste-cmd=.
+
+See =M-x customize-groups [RET] emacs-everywhere= for the full list. Or peak at the source.


### PR DESCRIPTION
defcustom for alternative methods of handling the clipboard on linux
also added documentation of the added as well as other customizations

Overlaps with issue #28 and maybe also a fix for issue #10

The modifications have at least a few weak spots.
  1. `emacs-everywhere-paste-cmd` should maybe be a function instead of a list passed onto `call-process`
  2. organization of added functions and vars
  3. `(eval `(... ,@args))` when `(apply ...)` is used elsewhere


----

1. There's a solid argument that it's easier to use as a list:
the intent is clearer and there is little ceremony.
but it is weaker (can't drop into elisp) and inconsistent with
`emacs-everywhere-filename-function` and `emacs-everywhere-linux-copy-function`

2. I get the sense things were well organized before I started poking around.
But I'm not deep enough into to understand what should go where.

3. `emacs-everywhere-call` uses
    (apply #'call-process command nil t nil (remq nil args))
  Just saw that. That looks cleaner than using eval. I'm here to
  practice lisp. Got carried away in emacs-everywhere-paste-cmd?