### PR TITLE
Fixes #42: Remove number-to-string for window-id

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -1,6 +1,6 @@
 ;;; emacs-everywhere.el --- System-wide popup windows for quick edits -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021 TEC
+;; Copyright (C) 2021, 2022 TEC
 
 ;; Author: TEC <https://github.com/tecosaur>
 ;; Maintainer: TEC <tec@tecosaur.com>
@@ -305,11 +305,16 @@ Never paste content when ABORT is non-nil."
                          (cdr emacs-everywhere-copy-command))))))
     (sleep-for 0.01) ; prevents weird multi-second pause, lets clipboard info propagate
     (when emacs-everywhere-window-focus-command
-      (let ((window-id (emacs-everywhere-app-id emacs-everywhere-current-app)))
+      (let* ((real-window-id (emacs-everywhere-app-id emacs-everywhere-current-app))
+             (window-id
+              (if (eq system-type 'darwin)
+                  real-window-id
+                (number-to-string real-window-id))))
+
         (apply #'call-process (car emacs-everywhere-window-focus-command)
                nil nil nil
                (mapcar (lambda (arg)
-                         (replace-regexp-in-string "%w" (number-to-string window-id) arg))
+                         (replace-regexp-in-string "%w" window-id arg))
                        (cdr emacs-everywhere-window-focus-command)))
         ;; The frame only has this parameter if this package initialized the temp
         ;; file its displaying. Otherwise, it was created by another program, likely


### PR DESCRIPTION
On macOS, window-id is a string (e.g. "firefox").  The conversion
from a number to a string is not required.