### PR TITLE
Auto-detect fails on X if loginctl lists multiple sessions for a given user

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -38,7 +38,7 @@
    ((memq system-type '(ms-dos windows-nt cygwin)) 'windows)
    ((executable-find "loginctl")
     (pcase (string-trim
-            (shell-command-to-string "loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type")
+            (shell-command-to-string "loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type | tail -1")
             "Type=" "\n")
       ("x11" 'x11)
       ("wayland" 'wayland)


### PR DESCRIPTION
Due to some issue with my system configuration, logout/logins were not closing my loginctl sessions, and this has unintentionally led me to discover a bug with emacs-everywhere. When multiple sessions are open, the output of the command...

```shell
loginctl show-session $(loginctl | grep $(whoami) | awk '{print $1}') -p Type
```

Fails to correctly evaluate to `"x11"`. Adding a `| tail -1` after fixes this.