### PR TITLE
fix void function of emacs-everywhere-major-mode-function

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -124,6 +124,10 @@ when applicable."
              text-mode)
   :group 'emacs-everywhere)
 
+(defun emacs-everywhere-major-mode-function ()
+  "Apply the major mode function."
+  (funcall emacs-everywhere-major-mode-function))
+
 (defcustom emacs-everywhere-init-hooks
   '(emacs-everywhere-set-frame-name
     emacs-everywhere-set-frame-position


### PR DESCRIPTION
Hi,

This package is awesome, but it failed to copy the initial selection to the buffer on
my side after installing from melpa.

After some investigation, I found that it has an error message:
> Emacs Everywhere: error running init hooks, (void-function emacs-everywhere-major-mode-function)

And it was introduced by the commit
cbe56e216df38756de11370535601b5324fdc63b.

This PR tries to fix it.

