### PR TITLE
Add experimental support for MS-Windows with occasional bugs

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -217,6 +217,7 @@ Make sure that it will be matched by `emacs-everywhere-file-patterns'."
       (_ (apply #'call-process "emacsclient" nil 0 nil param)))))
 
 (defun emacs-everywhere-command-param (app-info &optional file line colomn)
+  "Generate arguments for calling emacsclient."
   (delq
    nil (list
         (when (server-running-p)
@@ -543,6 +544,7 @@ return windowTitle"))
                         (- y 50))))
 
 (defun emacs-everywhere-insert-selection--windows ()
+  "Insert selection on MS-Windows by simulating C-c and C-v."
   (let* ((window-id (emacs-everywhere-app-id emacs-everywhere-current-app))
 	 (emacs-window-id (emacs-everywhere-call
 			   "powershell"

--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -45,6 +45,7 @@
   (pcase emacs-everywhere--display-server
     ('quartz (list "osascript" "-e" "tell application \"System Events\" to keystroke \"v\" using command down"))
     ('x11 (list "xdotool" "key" "--clearmodifiers" "Shift+Insert"))
+    ('windows (list "powershell" "-NoProfile" "-Command" "& {(New-Object -ComObject wscript.shell).SendKeys(\"^v\")}"))
     ((or 'wayland 'unknown)
      (list "notify-send"
            "No paste command defined for emacs-everywhere"
@@ -60,7 +61,8 @@ To not run any command, set to nil."
   (pcase emacs-everywhere--display-server
     ('x11 (list "xclip" "-selection" "clipboard" "%f"))
     ((and 'wayland (guard (executable-find "wl-copy")))
-     (list "sh" "-c" "wl-copy < %f")))
+     (list "sh" "-c" "wl-copy < %f"))
+    ('windows (list "Powershell" "-NoProfile" "-Command" "& { Get-Content %f | clip }")))
   "Command to write to the system clipboard from a file (%f).
 This is given as a list in the form (CMD ARGS...).
 In the arguments, \"%f\" is treated as a placeholder for the path
@@ -77,7 +79,9 @@ it worked can be a good idea."
 (defcustom emacs-everywhere-window-focus-command
   (pcase emacs-everywhere--display-server
     ('quartz (list "osascript" "-e" "tell application \"%w\" to activate"))
-    ('x11 (list "xdotool" "windowactivate" "--sync" "%w")))
+    ('x11 (list "xdotool" "windowactivate" "--sync" "%w"))
+    ('windows (list "powershell" "-NoProfile" "-command" "& {Add-Type 'using System; using System.Runtime.InteropServices; public class Tricks { [DllImport(\"user32.dll\")] public static extern bool SetForegroundWindow(IntPtr hWnd); }'; [tricks]::SetForegroundWindow(%w) }")))
+
   "Command to refocus the active window when emacs-everywhere was triggered.
 This is given as a list in the form (CMD ARGS...).
 In the arguments, \"%w\" is treated as a placeholder for the window ID,
@@ -206,28 +210,43 @@ Make sure that it will be matched by `emacs-everywhere-file-patterns'."
 ;;;###autoload
 (defun emacs-everywhere (&optional file line column)
   "Launch the emacs-everywhere frame from emacsclient."
-  (let ((app-info (emacs-everywhere-app-info)))
-    (apply #'call-process "emacsclient" nil 0 nil
-           (delq
-            nil (list
-                 (when (server-running-p)
-                   (if server-use-tcp
-                       (concat "--server-file="
-                               (shell-quote-argument
-                                (expand-file-name server-name server-auth-dir)))
-                     (concat "--socket-name="
-                             (shell-quote-argument
-                              (expand-file-name server-name server-socket-dir)))))
-                 "-c" "-F"
-                 (prin1-to-string
-                  (cons (cons 'emacs-everywhere-app app-info)
-                        emacs-everywhere-frame-parameters))
-                 (cond ((and line column) (format "+%d:%d" line column))
-                       (line              (format "+%d" line)))
-                 (or file
-                     (expand-file-name
-                      (funcall emacs-everywhere-filename-function app-info)
-                      emacs-everywhere-file-dir)))))))
+  (let* ((app-info (emacs-everywhere-app-info))
+	 (param (delq
+		 nil (list
+                      (when (server-running-p)
+			(if server-use-tcp
+			    (concat "--server-file="
+				    (if (memq system-type '(ms-dos windows-nt cygwin))
+					(expand-file-name server-name server-auth-dir)
+				      (shell-quote-argument
+				       (expand-file-name server-name server-auth-dir))))
+			  (concat "--socket-name="
+				  (if (memq system-type '(ms-dos windows-nt cygwin))
+				      (expand-file-name server-name server-auth-dir)
+				    (shell-quote-argument
+				     (expand-file-name server-name server-socket-dir)))
+				  )))
+                      "-c" "-F"
+		      ((lambda (condition arg) (if condition (concat "\""
+								     (replace-regexp-in-string "\"" "\\\\\"" arg) "\"") arg))
+		       (memq system-type '(ms-dos windows-nt cygwin))
+		       (prin1-to-string
+			(cons (cons 'emacs-everywhere-app app-info)
+                              emacs-everywhere-frame-parameters)))
+		 
+		      (cond ((and line column) (format "+%d:%d" line column))
+			    (line              (format "+%d" line)))
+
+		      (concat "\"" (or file
+				       (expand-file-name
+					(funcall emacs-everywhere-filename-function app-info)
+					emacs-everywhere-file-dir)) "\"")
+                      )))
+	 (param-string (mapconcat 'identity param " ")))
+    (pcase system-type
+      ((or 'ms-dos 'windows-nt 'cygwin) (w32-shell-execute "open" "emacsclientw" param-string 1))
+      (_ (apply #'call-process "emacsclient" nil 0 nil param))
+      )))
 
 (defun emacs-everywhere-file-p (file)
   "Return non-nil if FILE should be handled by emacs-everywhere.
@@ -330,12 +349,14 @@ Never paste content when ABORT is non-nil."
         (when (and (frame-parameter nil 'emacs-everywhere-app)
                    emacs-everywhere-paste-command
                    (not abort))
+	  (sleep-for 0.1)
+
           (apply #'call-process (car emacs-everywhere-paste-command)
                  nil nil nil (cdr emacs-everywhere-paste-command)))))
     ;; Clean up after ourselves in case the buffer survives `server-buffer-done'
     ;; (b/c `server-existing-buffer' is non-nil).
     (emacs-everywhere-mode -1)
-    (server-buffer-done (current-buffer))))
+    (server-kill-buffer)))
 
 (defun emacs-everywhere-abort ()
   "Abort current emacs-everywhere session."
@@ -353,6 +374,7 @@ Never paste content when ABORT is non-nil."
   "Return information on the active window."
   (let ((w (pcase system-type
              (`darwin (emacs-everywhere-app-info-osx))
+	     ((or `ms-dos `windows-nt `cygwin) (emacs-everywhere-app-info-windows))
              (_ (emacs-everywhere-app-info-linux)))))
     (setf (emacs-everywhere-app-title w)
           (replace-regexp-in-string
@@ -472,6 +494,35 @@ return windowTitle"))
         (shell-command (format "osacompile -r scpt:128 -t osas -o %s %s"
                                (car script) (concat (car script) ".applescript")))))))
 
+(defun emacs-everywhere-app-info-windows ()
+  "Return information on the active window, on Windows."
+  (let ((window-id (emacs-everywhere-call
+		    "powershell"
+		    "-NoProfile"
+		    "-Command"
+		    "& {Add-Type 'using System; using System.Runtime.InteropServices; public class Tricks { [DllImport(\"user32.dll\")] public static extern IntPtr GetForegroundWindow(); }'; [tricks]::GetForegroundWindow() }")))
+    (let ((window-title (emacs-everywhere-call
+			 "powershell"
+			 "-NoProfile"
+			 "-Command"
+			 (format "& {Add-Type 'using System; using System.Runtime.InteropServices; public class Tricks { [DllImport(\"user32.dll\")] public static extern int GetWindowText(IntPtr hWnd, System.Text.StringBuilder text, int count); [DllImport(\"user32.dll\")] public static extern int GetWindowTextLength(IntPtr hWnd); }'; $length = ([tricks]::GetWindowTextLength(%s)); $sb = New-Object System.Text.StringBuilder $length; [tricks]::GetWindowText(%s, $sb, $length + 1) > $null; $sb.ToString() }" window-id window-id)))
+	  (window-class (emacs-everywhere-call
+			 "powershell"
+			 "-NoProfile"
+			 "-Command"
+			 (format "(Get-Item (Get-Process | ? { $_.mainwindowhandle -eq %s }).Path).VersionInfo.ProductName" window-id)))
+	  (window-geometry (split-string (emacs-everywhere-call
+					  "powershell"
+					  "-NoProfile"
+					  "-Command"
+					  (format "& {Add-Type 'using System; using System.Runtime.InteropServices; public struct tagRECT { public int left; public int top; public int right; public int bottom; } public class Tricks { [DllImport(\"user32.dll\")] public static extern int GetWindowRect(IntPtr hWnd, out tagRECT lpRect); }'; $rect = New-Object -TypeName tagRECT; [tricks]::GetWindowRect(%s, [ref]$rect) > $null; $rect.left; $rect.top; $rect.right - $rect.left; $rect.bottom - $rect.top }" window-id)))))
+    
+      (make-emacs-everywhere-app
+       :id window-id
+       :class window-class
+       :title window-title
+       :geometry window-geometry))))
+
 ;;; Secondary functionality
 
 (defun emacs-everywhere-set-frame-name ()
@@ -498,15 +549,39 @@ return windowTitle"))
 
 (defun emacs-everywhere-insert-selection ()
   "Insert the last text selection into the buffer."
-  (if (eq system-type 'darwin)
-      (progn
-        (call-process "osascript" nil nil nil
-                      "-e" "tell application \"System Events\" to keystroke \"c\" using command down")
-        (sleep-for 0.01) ; lets clipboard info propagate
-        (yank))
-    (when-let ((selection (gui-get-selection 'PRIMARY 'UTF8_STRING)))
-      (gui-backend-set-selection 'PRIMARY "")
-      (insert selection)))
+  (pcase system-type
+    ('darwin (progn
+	       (call-process "osascript" nil nil nil
+			     "-e" "tell application \"System Events\" to keystroke \"c\" using command down")
+               (sleep-for 0.01)	       ; lets clipboard info propagate
+               (yank)))
+    ((or 'ms-dos 'windows-nt 'cygwin)
+     (progn
+       (let* ((window-id (emacs-everywhere-app-id emacs-everywhere-current-app))
+	      (emacs-window-id (emacs-everywhere-call
+				"powershell"
+				"-NoProfile"
+				"-Command"
+				"& {Add-Type 'using System; using System.Runtime.InteropServices; public class Tricks { [DllImport(\"user32.dll\")] public static extern IntPtr GetForegroundWindow(); }'; [tricks]::GetForegroundWindow() }")))
+	 (apply #'call-process (car emacs-everywhere-window-focus-command)
+		nil nil nil
+		(mapcar (lambda (arg)
+                          (replace-regexp-in-string "%w" window-id arg))
+			(cdr emacs-everywhere-window-focus-command)))
+	 (apply #'call-process "powershell"
+                nil nil nil '("-NoProfile" "-Command" "& {(New-Object -ComObject wscript.shell).SendKeys('^c')}"))
+	 (sleep-for 0.1)
+
+	 (apply #'call-process (car emacs-everywhere-window-focus-command)
+		nil nil nil
+		(mapcar (lambda (arg)
+                          (replace-regexp-in-string "%w" emacs-window-id arg))
+			(cdr emacs-everywhere-window-focus-command))))
+       (sleep-for 0.1)
+       (yank)))
+    (_ (when-let ((selection (gui-get-selection 'PRIMARY 'UTF8_STRING)))
+	 (gui-backend-set-selection 'PRIMARY "")
+	 (insert selection))))
   (when (and (eq major-mode 'org-mode)
              (emacs-everywhere-markdown-p)
              (executable-find "pandoc"))


### PR DESCRIPTION
I've tried to add MS-Windows support to emacs-everywhere and here is the outcome. It doesn't work as a charm: it works most of the time, however bugs take place randomly (there are possible solutions). But something is better than nothing.

The support is mainly introduced by defining paste/focus/copy/app-info commands, considering missing MS-Windows cases and making some modifications to `emacs-everywhere`, `emacs-everywhere-insert-selection` in order to handle some MS-Windows specific problems without affecting their original functions. 

Some drawbacks:

1. Heavy usage of calls to Win32 API through P/Invoke by PowerShell commands. The reason is that, as there lacks utilities like xdotool and AppleScript on MS-Windows, this is the only way to manipulate windows/frames without dependence on external tools. One who can withstand external tools or files can create wrapper for the commands with PowerShell script files or some simple C# programs by their own. 
2. Not universal. The commands simulate `C-c` and `C-v` to copy and paste selections between target window and Emacs, so whether it get the right selection depends on how the target window handles these keystrokes. For example, it cannot be used with TeXmacs, which uses Emacs-style keymap so `C-c` doesn't copy and `C-v` doesn't paste. There might be other approaches, such as sending WM_COPY message.
3. Instability. It cannot yank or do paste (though clipboard is actually changed) sometimes, this happens randomly. Possible solutions include telling the user to copy/paste manually before/after `emacs-everywhere`, which needs only two more keystrokes and will work like a charm. 
4. Slow speed. I don't know whether it is only my PC or generally the MS-Windows system that makes creating frames and calling processes very slow, yet acceptable.