### PR TITLE
Add emacs-everywhere-pandoc-args variable

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -202,7 +202,7 @@ Set to nil to disable."
   :type 'number
   :group 'emacs-everywhere)
 
-(defcustom emacs-everywhere-pandoc-args "-f markdown-auto_identifiers -t org"
+(defcustom emacs-everywhere-pandoc-args "-f markdown-auto_identifiers"
   "Arguments passed to pandoc to convert org into md."
   :type 'string
   :group 'emacs-everywhere)
@@ -637,7 +637,7 @@ return windowTitle"))
              (emacs-everywhere-markdown-p)
              (executable-find "pandoc"))
     (shell-command-on-region (point-min) (point-max)
-                             (format "pandoc %s" emacs-everywhere-pandoc-args) nil t)
+                             (format "pandoc %s -t org" emacs-everywhere-pandoc-args) nil t)
     (deactivate-mark) (goto-char (point-max)))
   (cond ((bound-and-true-p evil-local-mode) (evil-insert-state))))
 

--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -202,6 +202,11 @@ Set to nil to disable."
   :type 'number
   :group 'emacs-everywhere)
 
+(defcustom emacs-everywhere-pandoc-args "-f markdown-auto_identifiers -t org"
+  "Arguments passed to pandoc to convert org into md."
+  :type 'string
+  :group 'emacs-everywhere)
+
 (defun emacs-everywhere-temp-filename (app-info)
   "Generate a temp file."
   (concat "emacs-everywhere-"
@@ -632,7 +637,7 @@ return windowTitle"))
              (emacs-everywhere-markdown-p)
              (executable-find "pandoc"))
     (shell-command-on-region (point-min) (point-max)
-                             "pandoc -f markdown-auto_identifiers -t org" nil t)
+                             (format "pandoc %s" emacs-everywhere-pandoc-args) nil t)
     (deactivate-mark) (goto-char (point-max)))
   (cond ((bound-and-true-p evil-local-mode) (evil-insert-state))))
 


### PR DESCRIPTION
Allow users to provide custom flags to the pandoc org-to-markdown conversion command.