### PR TITLE
fine-tune 2 default settings

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -166,14 +166,15 @@ when applicable."
   :group 'emacs-everywhere)
 
 (defcustom emacs-everywhere-final-hooks
-  '(emacs-everywhere-remove-trailing-whitespace
-    emacs-everywhere-convert-org-to-gfm)
+  '(emacs-everywhere-convert-org-to-gfm
+    emacs-everywhere-remove-trailing-whitespace)
   "Hooks to be run just before content is copied."
   :type 'hook
   :group 'emacs-everywhere)
 
 (defcustom emacs-everywhere-frame-parameters
   `((name . "emacs-everywhere")
+    (fullscreen . nil)                  ; for GNOME at least
     (width . 80)
     (height . 12))
   "Parameters `make-frame' recognises to apply to the emacs-everywhere frame."


### PR DESCRIPTION
Hey TEC,

Here are 2 default setting improvements that I think would make sense:

1.  Also clean up trailing whitespaces for converted markdown contents.
2.  With `(add-to-list 'default-frame-alist '(fullscreen . maximized))`
    for Emacs on **GNOME**, the newly created EE frame will also be
    maximized without `(fullscreen . nil)`. It works after adding it
    (although the height is not what I specify, the result is better),
    and I think it makes sense to add this property in the parameters.