### PR TITLE
Correctly check that we should recompile osascript

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -721,25 +721,22 @@ Please go to 'System Preferences > Security & Privacy > Privacy > Accessibility'
 (defun emacs-everywhere--ensure-oscascript-compiled (&optional force)
   "Ensure that compiled oscascript files are present.
 Will always compile when FORCE is non-nil."
-  (unless (and (file-exists-p "app-name")
-               (file-exists-p "window-geometry")
-               (file-exists-p "window-title")
-               (not force))
-    (let ((default-directory emacs-everywhere--dir)
-          (app-name
-           "tell application \"System Events\"
+
+  (let ((default-directory emacs-everywhere--dir)
+        (app-name
+         "tell application \"System Events\"
     set frontAppName to name of first application process whose frontmost is true
 end tell
 return frontAppName")
-          (window-geometry
-           "tell application \"System Events\"
+        (window-geometry
+         "tell application \"System Events\"
      set frontWindow to front window of (first application process whose frontmost is true)
      set windowPosition to (get position of frontWindow)
      set windowSize to (get size of frontWindow)
 end tell
 return windowPosition & windowSize")
-          (window-title
-           "set windowTitle to \"\"
+        (window-title
+         "set windowTitle to \"\"
 tell application \"System Events\"
      set frontAppProcess to first application process whose frontmost is true
 end tell
@@ -749,6 +746,10 @@ tell frontAppProcess
     end if
 end tell
 return windowTitle"))
+    (unless (and (file-exists-p "app-name")
+                 (file-exists-p "window-geometry")
+                 (file-exists-p "window-title")
+                 (not force))
       (dolist (script `(("app-name" . ,app-name)
                         ("window-geometry" . ,window-geometry)
                         ("window-title" . ,window-title)))


### PR DESCRIPTION
This makes it noticeably faster on osx.

Hey! Just a tiny fix. Thanks for keeping this lib afloat.